### PR TITLE
update config yaml to add support to layout in A2 and A1

### DIFF
--- a/resources/geoserver/print/config.yaml
+++ b/resources/geoserver/print/config.yaml
@@ -1,4 +1,4 @@
- #===========================================================================
+#===========================================================================
 # allowed DPIs
 #===========================================================================
 dpis:
@@ -47,70 +47,29 @@ brokenUrlPlaceholder: http://demo.geo-solutions.it/print/blank.gif
 disableScaleLocking: true
 
 layouts:
-  #=======A4 portrait with legend=============================================
+  #==================================================
+  #========================A4========================
   A4 :
-  #===========================================================================
+  #==================================================
     mainPage:
       rotation: true
-      pageSize: 595 842 
+      pageSize: 595 842
       landscape: false
       items:
         - !columns
           absoluteX: 30
-          absoluteY: 800
-          width: 550
+          absoluteY: 812
+          width: 535
           items:
             - !image
-              maxWidth: 550
+              maxWidth: 535
+              maxHeight: 48
               url: '/${configDir}/print_header.png'
-        - !map
-          height: 600
-          width: 400
-          absoluteX: 30
-          absoluteY: 670
-        #legend panel            
-        - !columns               
-          config:
-            borderWidth: 1
-            cells:
-              - borderWidth: 2
-                borderWidthLeft: 1
-                borderColor: black
-                padding: 4
-                backgroundColor: white
-                vertAlign: bottom
-          widths: [155]
-          absoluteX: 435
-          absoluteY: 670
-          width: 155
-          items:
-            - !legends
-              horizontalAlignment: left
-              #iconMaxWidth: 150
-              maxWidth: 150
-              iconMaxHeight: 0
-              layerSpace: 5
-              layerFontSize: 12
-              classIndentation: 5
-              classFontSize: 8
-              classSpace: 4
-              backgroundColor: #ffffff
-              failOnBrokenUrl: false
-        - !columns
-          absoluteX: 370
-          absoluteY: 140
-          width: 40
-          items:
-            - !image
-              maxWidth: 40
-              maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
-              rotation: '${rotation}'     
         - !columns
           absoluteX: 30
           absoluteY: 740
-          width: 395
-          widths: [395]
+          width: 535
+          widths: [535]
           items:
             - !text
               align: left
@@ -119,62 +78,32 @@ layouts:
               text: '${mapTitle}'
         - !columns
           absoluteX: 30
-          absoluteY: 710
-          width: 395
-          widths: [395]
+          absoluteY: 692
+          width: 535
+          widths: [535]
           items:
             - !text
-              width: 300
-              text: '${comment}'  
-              fontEncoding: Cp1252
-              fontSize: 9                     
               align: left
-              vertAlign: middle   
-        - !columns
-          absoluteX: 30
-          absoluteY: 55
-          width: 395
-          widths: [240, 240]
-          items:
-            - !columns
-              nbColumns: 1
-              items:            
-                - !text
-                  width: 300
-                  text: '${now MM.dd.yyyy}'  
-                  fontEncoding: Cp1252
-                  fontSize: 9                     
-                  align: left
-                  vertAlign: middle
-            - !scalebar
-              align: right
               vertAlign: middle
-              maxSize: 200
-              type: 'bar sub'
-              intervals: 5
-  #=======A4 landscape with legend============================================
-  A4_landscape :
-  #===========================================================================
-    mainPage:
-      rotation: true
-      pageSize: 842 595
-      landscape: false
-      items:
-        - !columns
+              fontSize: 9
+              text: '${comment}'
+        - !map
           absoluteX: 30
-          absoluteY: 575
-          width: 782
+          absoluteY: 668
+          height: 590
+          width: 369
+        - !columns
+          absoluteX: 359
+          absoluteY: 138
+          width: 40
+          widths: [40]
           items:
             - !image
-              maxWidth: 782
-              url: '/${configDir}/print_header.png'
-        - !map
-          width: 592
-          height: 400
-          absoluteX:30
-          absoluteY:475
-        #legend panel            
-        - !columns               
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        #legend panel        - !columns
           config:
             borderWidth: 1
             cells:
@@ -184,14 +113,13 @@ layouts:
                 padding: 4
                 backgroundColor: white
                 vertAlign: bottom
-          widths: [170]
-          absoluteX: 642
-          absoluteY: 475
-          width: 170
+          widths: [160]
+          absoluteX: 405
+          absoluteY: 668
+          width: 160
           items:
             - !legends
               horizontalAlignment: left
-              #iconMaxWidth: 150
               maxWidth: 160
               iconMaxHeight: 0
               layerSpace: 5
@@ -199,88 +127,157 @@ layouts:
               classIndentation: 5
               classFontSize: 8
               classSpace: 4
-              backgroundColor: #ffffff
+              backgroundColor:  #ffffff
               failOnBrokenUrl: false
         - !columns
-          absoluteX: 590
-          absoluteY: 140
-          width: 40
-          items:
-            - !image
-              maxWidth: 40
-              maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
-              rotation: '${rotation}'          
-        - !columns
           absoluteX: 30
-          absoluteY: 55
-          width: 782
-          widths: [240, 300, 240]
+          absoluteY: 54
+          width: 369
+          widths: [123, 246]
           items:
             - !columns
               nbColumns: 1
               items:
                 - !text
-                  width: 300
-                  text: '${comment}'  
+                  width: 123
+                  text: '${now dd.MM.yyyy}'
                   fontEncoding: Cp1252
-                  fontSize: 9                     
-                  align: left
-                  vertAlign: middle               
-                - !text
-                  width: 300
-                  text: '${now MM.dd.yyyy}'  
-                  fontEncoding: Cp1252
-                  fontSize: 9                     
+                  fontSize: 9
                   align: left
                   vertAlign: middle
-            - !text
-              align: center
-              vertAlign: middle
-              fontSize: 14
-              text: '${mapTitle}'
             - !scalebar
               align: right
               vertAlign: middle
-              maxSize: 200
+              maxSize: 250
               type: 'bar sub'
               intervals: 5
-  #=======A4 portrait no legend=============================================
+  #==================================================
+  #===================A4_landscape===================
+  A4_landscape :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 842 595
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 565
+          width: 782
+          items:
+            - !image
+              maxWidth: 782
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 493
+          width: 782
+          widths: [782]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 445
+          width: 782
+          widths: [782]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 421
+          height: 343
+          width: 616
+        - !columns
+          absoluteX: 606
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        #legend panel        - !columns
+          config:
+            borderWidth: 1
+            cells:
+              - borderWidth: 2
+                borderWidthLeft: 1
+                borderColor: black
+                padding: 4
+                backgroundColor: white
+                vertAlign: bottom
+          widths: [160]
+          absoluteX: 652
+          absoluteY: 421
+          width: 160
+          items:
+            - !legends
+              horizontalAlignment: left
+              maxWidth: 160
+              iconMaxHeight: 0
+              layerSpace: 5
+              layerFontSize: 12
+              classIndentation: 5
+              classFontSize: 8
+              classSpace: 4
+              backgroundColor:  #ffffff
+              failOnBrokenUrl: false
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 616
+          widths: [205, 411]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 205
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+  #==================================================
+  #===================A4_no_legend===================
   A4_no_legend :
-  #=========================================================================
+  #==================================================
     mainPage:
       rotation: true
-      pageSize: 595 842 
+      pageSize: 595 842
       landscape: false
       items:
         - !columns
           absoluteX: 30
-          absoluteY: 800
-          width: 550
-          items:
-            - !image
-              maxWidth: 550
-              url: '/${configDir}/print_header.png'
-        - !map
-          height: 600
+          absoluteY: 812
           width: 535
-          absoluteX: 30
-          absoluteY: 670
-        - !columns
-          absoluteX: 510
-          absoluteY: 140
-          width: 40
           items:
             - !image
-              maxWidth: 40
-              maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
-              rotation: '${rotation}'     
+              maxWidth: 535
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
         - !columns
           absoluteX: 30
           absoluteY: 740
-          width: 395
-          widths: [395]
+          width: 535
+          widths: [535]
           items:
             - !text
               align: left
@@ -289,42 +286,57 @@ layouts:
               text: '${mapTitle}'
         - !columns
           absoluteX: 30
-          absoluteY: 710
-          width: 395
-          widths: [395]
+          absoluteY: 692
+          width: 535
+          widths: [535]
           items:
             - !text
-              width: 300
-              text: '${comment}'  
-              fontEncoding: Cp1252
-              fontSize: 9                     
               align: left
-              vertAlign: middle   
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 668
+          height: 590
+          width: 535
+        - !columns
+          absoluteX: 525
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
         - !columns
           absoluteX: 30
-          absoluteY: 55
+          absoluteY: 54
           width: 535
-          widths: [240, 240]
+          widths: [178, 357]
           items:
             - !columns
               nbColumns: 1
-              items:            
+              items:
                 - !text
-                  width: 300
-                  text: '${now MM.dd.yyyy}'  
+                  width: 178
+                  text: '${now dd.MM.yyyy}'
                   fontEncoding: Cp1252
-                  fontSize: 9                     
+                  fontSize: 9
                   align: left
                   vertAlign: middle
             - !scalebar
               align: right
               vertAlign: middle
-              maxSize: 200
+              maxSize: 250
               type: 'bar sub'
               intervals: 5
-  #=======A4 landscape no legend=============================================
+  #==================================================
+  #==============A4_no_legend_landscape==============
   A4_no_legend_landscape :
-  #===========================================================================
+  #==================================================
     mainPage:
       rotation: true
       pageSize: 842 595
@@ -332,97 +344,96 @@ layouts:
       items:
         - !columns
           absoluteX: 30
-          absoluteY: 575
+          absoluteY: 565
           width: 782
           items:
             - !image
               maxWidth: 782
+              maxHeight: 48
               url: '/${configDir}/print_header.png'
-        - !map
-          width: 780
-          height: 400
-          absoluteX:30
-          absoluteY:475
         - !columns
-          absoluteX: 750
-          absoluteY: 140
+          absoluteX: 30
+          absoluteY: 493
+          width: 782
+          widths: [782]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 445
+          width: 782
+          widths: [782]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 421
+          height: 343
+          width: 782
+        - !columns
+          absoluteX: 772
+          absoluteY: 138
           width: 40
+          widths: [40]
           items:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
-              rotation: '${rotation}'          
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
         - !columns
           absoluteX: 30
-          absoluteY: 55
+          absoluteY: 54
           width: 782
-          widths: [240, 300, 240]
+          widths: [260, 522]
           items:
             - !columns
               nbColumns: 1
               items:
                 - !text
-                  width: 300
-                  text: '${comment}'  
+                  width: 260
+                  text: '${now dd.MM.yyyy}'
                   fontEncoding: Cp1252
-                  fontSize: 9                     
-                  align: left
-                  vertAlign: middle               
-                - !text
-                  width: 300
-                  text: '${now MM.dd.yyyy}'  
-                  fontEncoding: Cp1252
-                  fontSize: 9                     
+                  fontSize: 9
                   align: left
                   vertAlign: middle
-            - !text
-              align: center
-              vertAlign: middle
-              fontSize: 14
-              text: '${mapTitle}'
             - !scalebar
               align: right
               vertAlign: middle
-              maxSize: 200
+              maxSize: 250
               type: 'bar sub'
               intervals: 5
-  #=======A4 portrait with 2 pages legend=====================================
+  #==================================================
+  #================A4_2_pages_legend=================
   A4_2_pages_legend :
-  #===========================================================================
+  #==================================================
     mainPage:
       rotation: true
-      pageSize: 595 842 
+      pageSize: 595 842
       landscape: false
       items:
         - !columns
           absoluteX: 30
-          absoluteY: 800
-          width: 550
-          items:
-            - !image
-              maxWidth: 550
-              url: '/${configDir}/print_header.png'
-        - !map
-          height: 600
+          absoluteY: 812
           width: 535
-          absoluteX: 30
-          absoluteY: 670
-        - !columns
-          absoluteX: 510
-          absoluteY: 140
-          width: 40
           items:
             - !image
-              maxWidth: 40
-              maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
-              rotation: '${rotation}'     
+              maxWidth: 535
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
         - !columns
           absoluteX: 30
           absoluteY: 740
-          width: 395
-          widths: [395]
+          width: 535
+          widths: [535]
           items:
             - !text
               align: left
@@ -431,45 +442,59 @@ layouts:
               text: '${mapTitle}'
         - !columns
           absoluteX: 30
-          absoluteY: 710
-          width: 395
-          widths: [395]
+          absoluteY: 692
+          width: 535
+          widths: [535]
           items:
             - !text
-              width: 300
-              text: '${comment}'  
-              fontEncoding: Cp1252
-              fontSize: 9                     
               align: left
-              vertAlign: middle   
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 668
+          height: 590
+          width: 535
+        - !columns
+          absoluteX: 525
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
         - !columns
           absoluteX: 30
-          absoluteY: 55
+          absoluteY: 54
           width: 535
-          widths: [240, 240]
+          widths: [178, 357]
           items:
             - !columns
               nbColumns: 1
-              items:            
+              items:
                 - !text
-                  width: 300
-                  text: '${now MM.dd.yyyy}'  
+                  width: 178
+                  text: '${now dd.MM.yyyy}'
                   fontEncoding: Cp1252
-                  fontSize: 9                     
+                  fontSize: 9
                   align: left
                   vertAlign: middle
             - !scalebar
               align: right
               vertAlign: middle
-              maxSize: 200
+              maxSize: 250
               type: 'bar sub'
               intervals: 5
     lastPage:
       rotation: true
-      pageSize: 595 842 
+      pageSize: 595 842
       landscape: false
-      items: 
-        #legend panel            
+      items:
+        #legend panel
         - !columns
           config:
             borderWidth: 0
@@ -480,31 +505,32 @@ layouts:
                 padding: 4
                 backgroundColor: white
                 vertAlign: bottom
-          widths: [500]
+          widths: [535]
           absoluteX: 30
-          absoluteY: 800
-          width: 500
+          absoluteY: 782
+          width: 535
           items:
-            - !legends      
+            - !legends
               failOnBrokenUrl: false
               horizontalAlignment: left
               iconMaxWidth: 0
-              iconMaxHeight: 700
-              maxHeight: 750
+              iconMaxHeight: 702
+              maxHeight: 752
               maxColumns: 1
-              maxWidth: 500
+              maxWidth: 535
               layerSpace: 5
               layerFontSize: 12
               classIndentation: 5
               classFontSize: 8
               classSpace: 4
-              backgroundColor: #ffffff                
-              reorderColumns: true    
-              dontBreakItems: true  
+              backgroundColor:  #ffffff
+              reorderColumns: true
+              dontBreakItems: true
               overflow: true
-  #=======A4 landscape with 2 pages legend====================================
+  #==================================================
+  #===========A4_2_pages_legend_landscape============
   A4_2_pages_legend_landscape :
-  #===========================================================================
+  #==================================================
     mainPage:
       rotation: true
       pageSize: 842 595
@@ -512,67 +538,79 @@ layouts:
       items:
         - !columns
           absoluteX: 30
-          absoluteY: 575
+          absoluteY: 565
           width: 782
           items:
             - !image
               maxWidth: 782
+              maxHeight: 48
               url: '/${configDir}/print_header.png'
-        - !map
-          width: 780
-          height: 400
-          absoluteX:30
-          absoluteY:475
         - !columns
-          absoluteX: 750
-          absoluteY: 140
+          absoluteX: 30
+          absoluteY: 493
+          width: 782
+          widths: [782]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 445
+          width: 782
+          widths: [782]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 421
+          height: 343
+          width: 782
+        - !columns
+          absoluteX: 772
+          absoluteY: 138
           width: 40
+          widths: [40]
           items:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
-              rotation: '${rotation}'          
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
         - !columns
           absoluteX: 30
-          absoluteY: 55
+          absoluteY: 54
           width: 782
-          widths: [240, 300, 240]
+          widths: [260, 522]
           items:
             - !columns
               nbColumns: 1
               items:
                 - !text
-                  width: 300
-                  text: '${comment}'  
+                  width: 260
+                  text: '${now dd.MM.yyyy}'
                   fontEncoding: Cp1252
-                  fontSize: 9                     
-                  align: left
-                  vertAlign: middle               
-                - !text
-                  width: 300
-                  text: '${now MM.dd.yyyy}'  
-                  fontEncoding: Cp1252
-                  fontSize: 9                     
+                  fontSize: 9
                   align: left
                   vertAlign: middle
-            - !text
-              align: center
-              vertAlign: middle
-              fontSize: 14
-              text: '${mapTitle}'
             - !scalebar
               align: right
               vertAlign: middle
-              maxSize: 200
+              maxSize: 250
               type: 'bar sub'
               intervals: 5
     lastPage:
       rotation: true
       pageSize: 842 595
       landscape: false
-      items: 
-        #legend panel            
+      items:
+        #legend panel
         - !columns
           config:
             borderWidth: 0
@@ -583,51 +621,85 @@ layouts:
                 padding: 4
                 backgroundColor: white
                 vertAlign: bottom
-          absoluteX:30
+          widths: [782]
+          absoluteX: 30
           absoluteY: 535
-          width: 780
-          widths: [780]
+          width: 782
           items:
-            - !legends      
+            - !legends
               failOnBrokenUrl: false
               horizontalAlignment: left
               iconMaxWidth: 0
-              iconMaxHeight: 500
-              maxHeight: 535
-              maxColumns: 2
-              maxWidth: 780
+              iconMaxHeight: 455
+              maxHeight: 505
+              maxColumns: 1
+              maxWidth: 782
               layerSpace: 5
               layerFontSize: 12
               classIndentation: 5
               classFontSize: 8
               classSpace: 4
-              backgroundColor: #ffffff   
-              reorderColumns: true    
-              dontBreakItems: true    
+              backgroundColor:  #ffffff
+              reorderColumns: true
+              dontBreakItems: true
               overflow: true
-  #=======A3 portrait with legend=============================================
+  #==================================================
+  #========================A3========================
   A3 :
-  #===========================================================================
+  #==================================================
     mainPage:
       rotation: true
       pageSize: 842 1190
       landscape: false
       items:
         - !columns
-          absoluteX: 42
-          absoluteY: 1150
-          width: 800
+          absoluteX: 30
+          absoluteY: 1160
+          width: 782
           items:
             - !image
-              maxWidth: 800
+              maxWidth: 782
+              maxHeight: 48
               url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1088
+          width: 782
+          widths: [782]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1040
+          width: 782
+          widths: [782]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
         - !map
-          width: 550
-          height: 850
-          absoluteX: 42
-          absoluteY: 950
-        #legend panel            
-        - !columns               
+          absoluteX: 30
+          absoluteY: 1016
+          height: 938
+          width: 574
+        - !columns
+          absoluteX: 564
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        #legend panel        - !columns
           config:
             borderWidth: 1
             cells:
@@ -637,350 +709,67 @@ layouts:
                 padding: 4
                 backgroundColor: white
                 vertAlign: bottom
-          widths: [241]
-          absoluteX: 598
-          absoluteY: 950
-          width: 240
+          widths: [200]
+          absoluteX: 612
+          absoluteY: 1016
+          width: 200
           items:
             - !legends
               horizontalAlignment: left
-              #iconMaxWidth: 150
-              maxWidth: 240
+              maxWidth: 200
               iconMaxHeight: 0
               layerSpace: 5
               layerFontSize: 12
               classIndentation: 5
               classFontSize: 8
               classSpace: 4
-              backgroundColor: #ffffff
-              failOnBrokenUrl: false  
+              backgroundColor:  #ffffff
+              failOnBrokenUrl: false
         - !columns
-          absoluteX: 540
-          absoluteY: 180
-          width: 40
-          items:
-            - !image
-              maxWidth: 40
-              maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
-              rotation: '${rotation}'
-        - !columns
-          absoluteX: 42
-          absoluteY: 1050
-          width: 424
-          widths: [424]
-          items:
-            - !text
-              align: left
-              vertAlign: middle
-              fontSize: 14
-              text: '${mapTitle}'
-        - !columns
-          absoluteX: 42
-          absoluteY: 1000
-          width: 424
-          widths: [424]
-          items:
-            - !text
-              width: 424
-              text: '${comment}'  
-              fontEncoding: Cp1252
-              fontSize: 9                     
-              align: left
-              vertAlign: middle         
-        - !columns
-          absoluteX: 42
-          absoluteY: 50
-          width: 550
-          widths: [340, 424]
-          items:
-            - !columns
-              nbColumns: 1
-              items:            
-                - !text
-                  width: 424
-                  text: '${now MM.dd.yyyy}'  
-                  fontEncoding: Cp1252
-                  fontSize: 9                     
-                  align: left
-                  vertAlign: middle
-            - !scalebar
-              align: right
-              vertAlign: middle
-              maxSize: 200
-              type: 'bar sub'
-              intervals: 5         
-  #=======A3 landscape with legend============================================
-  A3_landscape :
-  #===========================================================================
-    mainPage:
-      rotation: true
-      pageSize: 1190 842
-      landscape: false
-      items:
-        - !columns
-          absoluteX: 42
-          absoluteY: 814
-          width: 1105
-          items:
-            - !image
-              maxWidth: 1105
-              url: '/${configDir}/print_header.png'
-        - !map
-          width: 837
-          height: 594
-          absoluteX:42
-          absoluteY:700
-        #legend panel            
-        - !columns               
-          config:
-            borderWidth: 1
-            cells:
-              - borderWidth: 2
-                borderWidthLeft: 1
-                borderColor: black
-                padding: 4
-                backgroundColor: white
-                vertAlign: bottom
-          widths: [241]
-          absoluteX: 907
-          absoluteY: 700
-          width: 240
-          items:
-            - !legends
-              horizontalAlignment: left
-              #iconMaxWidth: 150
-              maxWidth: 240
-              iconMaxHeight: 0
-              layerSpace: 5
-              layerFontSize: 12
-              classIndentation: 5
-              classFontSize: 8
-              classSpace: 4
-              backgroundColor: #ffffff
-              failOnBrokenUrl: false  
-        - !columns
-          absoluteX: 800
-          absoluteY: 170
-          width: 40
-          items:
-            - !image
-              maxWidth: 40
-              maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
-              rotation: '${rotation}'          
-        - !columns
-          absoluteX: 42
-          absoluteY: 78
-          width: 1105
-          widths: [340, 424, 340]
+          absoluteX: 30
+          absoluteY: 54
+          width: 574
+          widths: [191, 383]
           items:
             - !columns
               nbColumns: 1
               items:
                 - !text
-                  width: 424
-                  text: '${comment}'  
+                  width: 191
+                  text: '${now dd.MM.yyyy}'
                   fontEncoding: Cp1252
-                  fontSize: 9                     
-                  align: left
-                  vertAlign: middle               
-                - !text
-                  width: 424
-                  text: '${now MM.dd.yyyy}'  
-                  fontEncoding: Cp1252
-                  fontSize: 9                     
-                  align: left
-                  vertAlign: middle
-            - !text
-              align: center
-              vertAlign: middle
-              fontSize: 14
-              text: '${mapTitle}'
-            - !scalebar
-              align: right
-              vertAlign: middle
-              maxSize: 200
-              type: 'bar sub'
-              intervals: 5             
-  #=======A3 portrait no legend============================================
-  A3_no_legend :
-  #========================================================================
-    mainPage:
-      rotation: true
-      pageSize: 842 1190
-      landscape: false
-      items:
-        - !columns
-          absoluteX: 42
-          absoluteY: 1150
-          width: 780
-          items:
-            - !image
-              maxWidth: 780
-              url: '/${configDir}/print_header.png'
-        - !map
-          width: 760
-          height: 850
-          absoluteX: 42
-          absoluteY: 950
-        - !columns
-          absoluteX: 730
-          absoluteY: 180
-          width: 40
-          items:
-            - !image
-              maxWidth: 40
-              maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
-              rotation: '${rotation}'
-        - !columns
-          absoluteX: 42
-          absoluteY: 1050
-          width: 424
-          widths: [424]
-          items:
-            - !text
-              align: left
-              vertAlign: middle
-              fontSize: 14
-              text: '${mapTitle}'
-        - !columns
-          absoluteX: 42
-          absoluteY: 1000
-          width: 424
-          widths: [424]
-          items:
-            - !text
-              width: 424
-              text: '${comment}'  
-              fontEncoding: Cp1252
-              fontSize: 9                     
-              align: left
-              vertAlign: middle         
-        - !columns
-          absoluteX: 42
-          absoluteY: 50
-          width: 760
-          widths: [340, 424]
-          items:
-            - !columns
-              nbColumns: 1
-              items:            
-                - !text
-                  width: 424
-                  text: '${now MM.dd.yyyy}'  
-                  fontEncoding: Cp1252
-                  fontSize: 9                     
+                  fontSize: 9
                   align: left
                   vertAlign: middle
             - !scalebar
               align: right
               vertAlign: middle
-              maxSize: 200
-              type: 'bar sub'
-              intervals: 5    
-  #=======A3 landscape no legend============================================
-  A3_no_legend_landscape :
-  #=========================================================================
-    mainPage:
-      rotation: true
-      pageSize: 1190 842
-      landscape: false
-      items:
-        - !columns
-          absoluteX: 42
-          absoluteY: 814
-          width: 1105
-          items:
-            - !image
-              maxWidth: 1105
-              url: '/${configDir}/print_header.png'
-        - !map
-          width: 1102
-          height: 594
-          absoluteX:42
-          absoluteY:700
-        - !columns
-          absoluteX: 1060
-          absoluteY: 198
-          width: 40
-          items:
-            - !image
-              maxWidth: 40
-              maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
-              rotation: '${rotation}'          
-        - !columns
-          absoluteX: 42
-          absoluteY: 78
-          width: 1105
-          widths: [339, 424, 339]
-          items:
-            - !columns
-              nbColumns: 1
-              items:
-                - !text
-                  width: 424
-                  text: '${comment}'  
-                  fontEncoding: Cp1252
-                  fontSize: 9                     
-                  align: left
-                  vertAlign: middle               
-                - !text
-                  width: 424
-                  text: '${now MM.dd.yyyy}'  
-                  fontEncoding: Cp1252
-                  fontSize: 9                     
-                  align: left
-                  vertAlign: middle
-            - !text
-              align: center
-              vertAlign: middle
-              fontSize: 14
-              text: '${mapTitle}'
-            - !scalebar
-              align: right
-              vertAlign: middle
-              maxSize: 200
+              maxSize: 250
               type: 'bar sub'
               intervals: 5
-  #=======A3 portrait two pages legend======================================
-  A3_2_pages_legend :
-  #=========================================================================
+  #==================================================
+  #===================A3_landscape===================
+  A3_landscape :
+  #==================================================
     mainPage:
       rotation: true
-      pageSize: 842 1190
+      pageSize: 1190 842
       landscape: false
       items:
         - !columns
-          absoluteX: 42
-          absoluteY: 1150
-          width: 780
+          absoluteX: 30
+          absoluteY: 812
+          width: 1130
           items:
             - !image
-              maxWidth: 780
+              maxWidth: 1130
+              maxHeight: 48
               url: '/${configDir}/print_header.png'
-        - !map
-          width: 760
-          height: 850
-          absoluteX: 42
-          absoluteY: 950
         - !columns
-          absoluteX: 730
-          absoluteY: 180
-          width: 40
-          items:
-            - !image
-              maxWidth: 40
-              maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
-              rotation: '${rotation}'
-        - !columns
-          absoluteX: 42
-          absoluteY: 1050
-          width: 424
-          widths: [424]
+          absoluteX: 30
+          absoluteY: 740
+          width: 1130
+          widths: [1130]
           items:
             - !text
               align: left
@@ -988,46 +777,320 @@ layouts:
               fontSize: 14
               text: '${mapTitle}'
         - !columns
-          absoluteX: 42
-          absoluteY: 1000
-          width: 424
-          widths: [424]
+          absoluteX: 30
+          absoluteY: 692
+          width: 1130
+          widths: [1130]
           items:
             - !text
-              width: 424
-              text: '${comment}'  
-              fontEncoding: Cp1252
-              fontSize: 9                     
               align: left
-              vertAlign: middle         
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 668
+          height: 590
+          width: 922
         - !columns
-          absoluteX: 42
-          absoluteY: 50
-          width: 760
-          widths: [340, 424]
+          absoluteX: 912
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        #legend panel        - !columns
+          config:
+            borderWidth: 1
+            cells:
+              - borderWidth: 2
+                borderWidthLeft: 1
+                borderColor: black
+                padding: 4
+                backgroundColor: white
+                vertAlign: bottom
+          widths: [200]
+          absoluteX: 960
+          absoluteY: 668
+          width: 200
+          items:
+            - !legends
+              horizontalAlignment: left
+              maxWidth: 200
+              iconMaxHeight: 0
+              layerSpace: 5
+              layerFontSize: 12
+              classIndentation: 5
+              classFontSize: 8
+              classSpace: 4
+              backgroundColor:  #ffffff
+              failOnBrokenUrl: false
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 922
+          widths: [307, 615]
           items:
             - !columns
               nbColumns: 1
-              items:            
+              items:
                 - !text
-                  width: 424
-                  text: '${now MM.dd.yyyy}'  
+                  width: 307
+                  text: '${now dd.MM.yyyy}'
                   fontEncoding: Cp1252
-                  fontSize: 9                     
+                  fontSize: 9
                   align: left
                   vertAlign: middle
             - !scalebar
               align: right
               vertAlign: middle
-              maxSize: 200
+              maxSize: 250
               type: 'bar sub'
-              intervals: 5   
+              intervals: 5
+  #==================================================
+  #===================A3_no_legend===================
+  A3_no_legend :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 842 1190
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 1160
+          width: 782
+          items:
+            - !image
+              maxWidth: 782
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1088
+          width: 782
+          widths: [782]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1040
+          width: 782
+          widths: [782]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 1016
+          height: 938
+          width: 782
+        - !columns
+          absoluteX: 772
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 782
+          widths: [260, 522]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 260
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+  #==================================================
+  #==============A3_no_legend_landscape==============
+  A3_no_legend_landscape :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 1190 842
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 812
+          width: 1130
+          items:
+            - !image
+              maxWidth: 1130
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 740
+          width: 1130
+          widths: [1130]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 692
+          width: 1130
+          widths: [1130]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 668
+          height: 590
+          width: 1130
+        - !columns
+          absoluteX: 1120
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 1130
+          widths: [376, 754]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 376
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+  #==================================================
+  #================A3_2_pages_legend=================
+  A3_2_pages_legend :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 842 1190
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 1160
+          width: 782
+          items:
+            - !image
+              maxWidth: 782
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1088
+          width: 782
+          widths: [782]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1040
+          width: 782
+          widths: [782]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 1016
+          height: 938
+          width: 782
+        - !columns
+          absoluteX: 772
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 782
+          widths: [260, 522]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 260
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
     lastPage:
       rotation: true
-      pageSize: 842 1190 
+      pageSize: 842 1190
       landscape: false
-      items: 
-        #legend panel            
+      items:
+        #legend panel
         - !columns
           config:
             borderWidth: 0
@@ -1038,99 +1101,112 @@ layouts:
                 padding: 4
                 backgroundColor: white
                 vertAlign: bottom
-          widths: [440]
+          widths: [782]
           absoluteX: 30
-          absoluteY: 1150
-          width: 440
+          absoluteY: 1130
+          width: 782
           items:
-            - !legends      
+            - !legends
               failOnBrokenUrl: false
               horizontalAlignment: left
               iconMaxWidth: 0
               iconMaxHeight: 1050
-              maxHeight: 1050
-              maxColumns: 2
-              maxWidth: 800
+              maxHeight: 1100
+              maxColumns: 1
+              maxWidth: 782
               layerSpace: 5
               layerFontSize: 12
               classIndentation: 5
               classFontSize: 8
               classSpace: 4
-              backgroundColor: #ffffff 
-              reorderColumns: true    
-              dontBreakItems: true    
+              backgroundColor:  #ffffff
+              reorderColumns: true
+              dontBreakItems: true
               overflow: true
-  #===========================================================================
+  #==================================================
+  #===========A3_2_pages_legend_landscape============
   A3_2_pages_legend_landscape :
-  #===========================================================================
+  #==================================================
     mainPage:
       rotation: true
       pageSize: 1190 842
       landscape: false
       items:
         - !columns
-          absoluteX: 42
-          absoluteY: 814
-          width: 1105
+          absoluteX: 30
+          absoluteY: 812
+          width: 1130
           items:
             - !image
-              maxWidth: 1105
+              maxWidth: 1130
+              maxHeight: 48
               url: '/${configDir}/print_header.png'
-        - !map
-          width: 1102
-          height: 594
-          absoluteX:42
-          absoluteY:700
         - !columns
-          absoluteX: 1070
-          absoluteY: 198
+          absoluteX: 30
+          absoluteY: 740
+          width: 1130
+          widths: [1130]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 692
+          width: 1130
+          widths: [1130]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 668
+          height: 590
+          width: 1130
+        - !columns
+          absoluteX: 1120
+          absoluteY: 138
           width: 40
+          widths: [40]
           items:
             - !image
               maxWidth: 40
               maxHeight: 40
-              url: 'file:/${configDir}/Arrow_North_CFCF.svg'
-              rotation: '${rotation}'          
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
         - !columns
-          absoluteX: 42
-          absoluteY: 78
-          width: 1105
-          widths: [339, 424, 339]
+          absoluteX: 30
+          absoluteY: 54
+          width: 1130
+          widths: [376, 754]
           items:
             - !columns
               nbColumns: 1
               items:
                 - !text
-                  width: 424
-                  text: '${comment}'  
+                  width: 376
+                  text: '${now dd.MM.yyyy}'
                   fontEncoding: Cp1252
-                  fontSize: 9                     
-                  align: left
-                  vertAlign: middle               
-                - !text
-                  width: 424
-                  text: '${now MM.dd.yyyy}'  
-                  fontEncoding: Cp1252
-                  fontSize: 9                     
+                  fontSize: 9
                   align: left
                   vertAlign: middle
-            - !text
-              align: center
-              vertAlign: middle
-              fontSize: 14
-              text: '${mapTitle}'
             - !scalebar
               align: right
               vertAlign: middle
-              maxSize: 200
+              maxSize: 250
               type: 'bar sub'
               intervals: 5
     lastPage:
       rotation: true
       pageSize: 1190 842
       landscape: false
-      items: 
-        #legend panel            
+      items:
+        #legend panel
         - !columns
           config:
             borderWidth: 0
@@ -1141,25 +1217,1217 @@ layouts:
                 padding: 4
                 backgroundColor: white
                 vertAlign: bottom
-          absoluteX:30
-          absoluteY: 800
-          width: 780
-          widths: [780]
+          widths: [1130]
+          absoluteX: 30
+          absoluteY: 782
+          width: 1130
           items:
-            - !legends      
+            - !legends
               failOnBrokenUrl: false
               horizontalAlignment: left
               iconMaxWidth: 0
-              iconMaxHeight: 700
-              maxHeight: 700
-              maxColumns: 3
-              maxWidth: 1000
+              iconMaxHeight: 702
+              maxHeight: 752
+              maxColumns: 1
+              maxWidth: 1130
               layerSpace: 5
               layerFontSize: 12
               classIndentation: 5
               classFontSize: 8
               classSpace: 4
-              backgroundColor: #ffffff   
-              reorderColumns: true    
-              dontBreakItems: true       
-              overflow: true        
+              backgroundColor:  #ffffff
+              reorderColumns: true
+              dontBreakItems: true
+              overflow: true
+  #==================================================
+  #========================A2========================
+  A2 :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 1190 1684
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 1654
+          width: 1130
+          items:
+            - !image
+              maxWidth: 1130
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1582
+          width: 1130
+          widths: [1130]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1534
+          width: 1130
+          widths: [1130]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 1510
+          height: 1432
+          width: 872
+        - !columns
+          absoluteX: 862
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        #legend panel        - !columns
+          config:
+            borderWidth: 1
+            cells:
+              - borderWidth: 2
+                borderWidthLeft: 1
+                borderColor: black
+                padding: 4
+                backgroundColor: white
+                vertAlign: bottom
+          widths: [250]
+          absoluteX: 910
+          absoluteY: 1510
+          width: 250
+          items:
+            - !legends
+              horizontalAlignment: left
+              maxWidth: 250
+              iconMaxHeight: 0
+              layerSpace: 5
+              layerFontSize: 12
+              classIndentation: 5
+              classFontSize: 8
+              classSpace: 4
+              backgroundColor:  #ffffff
+              failOnBrokenUrl: false
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 872
+          widths: [290, 582]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 290
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+  #==================================================
+  #===================A2_landscape===================
+  A2_landscape :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 1684 1190
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 1160
+          width: 1624
+          items:
+            - !image
+              maxWidth: 1624
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1088
+          width: 1624
+          widths: [1624]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1040
+          width: 1624
+          widths: [1624]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 1016
+          height: 938
+          width: 1366
+        - !columns
+          absoluteX: 1356
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        #legend panel        - !columns
+          config:
+            borderWidth: 1
+            cells:
+              - borderWidth: 2
+                borderWidthLeft: 1
+                borderColor: black
+                padding: 4
+                backgroundColor: white
+                vertAlign: bottom
+          widths: [250]
+          absoluteX: 1404
+          absoluteY: 1016
+          width: 250
+          items:
+            - !legends
+              horizontalAlignment: left
+              maxWidth: 250
+              iconMaxHeight: 0
+              layerSpace: 5
+              layerFontSize: 12
+              classIndentation: 5
+              classFontSize: 8
+              classSpace: 4
+              backgroundColor:  #ffffff
+              failOnBrokenUrl: false
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 1366
+          widths: [455, 911]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 455
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+  #==================================================
+  #===================A2_no_legend===================
+  A2_no_legend :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 1190 1684
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 1654
+          width: 1130
+          items:
+            - !image
+              maxWidth: 1130
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1582
+          width: 1130
+          widths: [1130]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1534
+          width: 1130
+          widths: [1130]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 1510
+          height: 1432
+          width: 1130
+        - !columns
+          absoluteX: 1120
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 1130
+          widths: [376, 754]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 376
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+  #==================================================
+  #==============A2_no_legend_landscape==============
+  A2_no_legend_landscape :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 1684 1190
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 1160
+          width: 1624
+          items:
+            - !image
+              maxWidth: 1624
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1088
+          width: 1624
+          widths: [1624]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1040
+          width: 1624
+          widths: [1624]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 1016
+          height: 938
+          width: 1624
+        - !columns
+          absoluteX: 1614
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 1624
+          widths: [541, 1083]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 541
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+  #==================================================
+  #================A2_2_pages_legend=================
+  A2_2_pages_legend :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 1190 1684
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 1654
+          width: 1130
+          items:
+            - !image
+              maxWidth: 1130
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1582
+          width: 1130
+          widths: [1130]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1534
+          width: 1130
+          widths: [1130]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 1510
+          height: 1432
+          width: 1130
+        - !columns
+          absoluteX: 1120
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 1130
+          widths: [376, 754]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 376
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+    lastPage:
+      rotation: true
+      pageSize: 1190 1684
+      landscape: false
+      items:
+        #legend panel
+        - !columns
+          config:
+            borderWidth: 0
+            cells:
+              - borderWidth: 0
+                borderWidthLeft: 0
+                borderColor: black
+                padding: 4
+                backgroundColor: white
+                vertAlign: bottom
+          widths: [1130]
+          absoluteX: 30
+          absoluteY: 1624
+          width: 1130
+          items:
+            - !legends
+              failOnBrokenUrl: false
+              horizontalAlignment: left
+              iconMaxWidth: 0
+              iconMaxHeight: 1544
+              maxHeight: 1594
+              maxColumns: 1
+              maxWidth: 1130
+              layerSpace: 5
+              layerFontSize: 12
+              classIndentation: 5
+              classFontSize: 8
+              classSpace: 4
+              backgroundColor:  #ffffff
+              reorderColumns: true
+              dontBreakItems: true
+              overflow: true
+  #==================================================
+  #===========A2_2_pages_legend_landscape============
+  A2_2_pages_legend_landscape :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 1684 1190
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 1160
+          width: 1624
+          items:
+            - !image
+              maxWidth: 1624
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1088
+          width: 1624
+          widths: [1624]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1040
+          width: 1624
+          widths: [1624]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 1016
+          height: 938
+          width: 1624
+        - !columns
+          absoluteX: 1614
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 1624
+          widths: [541, 1083]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 541
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+    lastPage:
+      rotation: true
+      pageSize: 1684 1190
+      landscape: false
+      items:
+        #legend panel
+        - !columns
+          config:
+            borderWidth: 0
+            cells:
+              - borderWidth: 0
+                borderWidthLeft: 0
+                borderColor: black
+                padding: 4
+                backgroundColor: white
+                vertAlign: bottom
+          widths: [1624]
+          absoluteX: 30
+          absoluteY: 1130
+          width: 1624
+          items:
+            - !legends
+              failOnBrokenUrl: false
+              horizontalAlignment: left
+              iconMaxWidth: 0
+              iconMaxHeight: 1050
+              maxHeight: 1100
+              maxColumns: 1
+              maxWidth: 1624
+              layerSpace: 5
+              layerFontSize: 12
+              classIndentation: 5
+              classFontSize: 8
+              classSpace: 4
+              backgroundColor:  #ffffff
+              reorderColumns: true
+              dontBreakItems: true
+              overflow: true
+  #==================================================
+  #========================A1========================
+  A1 :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 1684 2380
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 2350
+          width: 1624
+          items:
+            - !image
+              maxWidth: 1624
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 2278
+          width: 1624
+          widths: [1624]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 2230
+          width: 1624
+          widths: [1624]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 2206
+          height: 2128
+          width: 1316
+        - !columns
+          absoluteX: 1306
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        #legend panel        - !columns
+          config:
+            borderWidth: 1
+            cells:
+              - borderWidth: 2
+                borderWidthLeft: 1
+                borderColor: black
+                padding: 4
+                backgroundColor: white
+                vertAlign: bottom
+          widths: [300]
+          absoluteX: 1354
+          absoluteY: 2206
+          width: 300
+          items:
+            - !legends
+              horizontalAlignment: left
+              maxWidth: 300
+              iconMaxHeight: 0
+              layerSpace: 5
+              layerFontSize: 12
+              classIndentation: 5
+              classFontSize: 8
+              classSpace: 4
+              backgroundColor:  #ffffff
+              failOnBrokenUrl: false
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 1316
+          widths: [438, 878]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 438
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+  #==================================================
+  #===================A1_landscape===================
+  A1_landscape :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 2380 1684
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 1654
+          width: 2320
+          items:
+            - !image
+              maxWidth: 2320
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1582
+          width: 2320
+          widths: [2320]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1534
+          width: 2320
+          widths: [2320]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 1510
+          height: 1432
+          width: 2012
+        - !columns
+          absoluteX: 2002
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        #legend panel        - !columns
+          config:
+            borderWidth: 1
+            cells:
+              - borderWidth: 2
+                borderWidthLeft: 1
+                borderColor: black
+                padding: 4
+                backgroundColor: white
+                vertAlign: bottom
+          widths: [300]
+          absoluteX: 2050
+          absoluteY: 1510
+          width: 300
+          items:
+            - !legends
+              horizontalAlignment: left
+              maxWidth: 300
+              iconMaxHeight: 0
+              layerSpace: 5
+              layerFontSize: 12
+              classIndentation: 5
+              classFontSize: 8
+              classSpace: 4
+              backgroundColor:  #ffffff
+              failOnBrokenUrl: false
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 2012
+          widths: [670, 1342]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 670
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+  #==================================================
+  #===================A1_no_legend===================
+  A1_no_legend :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 1684 2380
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 2350
+          width: 1624
+          items:
+            - !image
+              maxWidth: 1624
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 2278
+          width: 1624
+          widths: [1624]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 2230
+          width: 1624
+          widths: [1624]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 2206
+          height: 2128
+          width: 1624
+        - !columns
+          absoluteX: 1614
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 1624
+          widths: [541, 1083]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 541
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+  #==================================================
+  #==============A1_no_legend_landscape==============
+  A1_no_legend_landscape :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 2380 1684
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 1654
+          width: 2320
+          items:
+            - !image
+              maxWidth: 2320
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1582
+          width: 2320
+          widths: [2320]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1534
+          width: 2320
+          widths: [2320]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 1510
+          height: 1432
+          width: 2320
+        - !columns
+          absoluteX: 2310
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 2320
+          widths: [773, 1547]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 773
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+  #==================================================
+  #================A1_2_pages_legend=================
+  A1_2_pages_legend :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 1684 2380
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 2350
+          width: 1624
+          items:
+            - !image
+              maxWidth: 1624
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 2278
+          width: 1624
+          widths: [1624]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 2230
+          width: 1624
+          widths: [1624]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 2206
+          height: 2128
+          width: 1624
+        - !columns
+          absoluteX: 1614
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 1624
+          widths: [541, 1083]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 541
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+    lastPage:
+      rotation: true
+      pageSize: 1684 2380
+      landscape: false
+      items:
+        #legend panel
+        - !columns
+          config:
+            borderWidth: 0
+            cells:
+              - borderWidth: 0
+                borderWidthLeft: 0
+                borderColor: black
+                padding: 4
+                backgroundColor: white
+                vertAlign: bottom
+          widths: [1624]
+          absoluteX: 30
+          absoluteY: 2320
+          width: 1624
+          items:
+            - !legends
+              failOnBrokenUrl: false
+              horizontalAlignment: left
+              iconMaxWidth: 0
+              iconMaxHeight: 2240
+              maxHeight: 2290
+              maxColumns: 1
+              maxWidth: 1624
+              layerSpace: 5
+              layerFontSize: 12
+              classIndentation: 5
+              classFontSize: 8
+              classSpace: 4
+              backgroundColor:  #ffffff
+              reorderColumns: true
+              dontBreakItems: true
+              overflow: true
+  #==================================================
+  #===========A1_2_pages_legend_landscape============
+  A1_2_pages_legend_landscape :
+  #==================================================
+    mainPage:
+      rotation: true
+      pageSize: 2380 1684
+      landscape: false
+      items:
+        - !columns
+          absoluteX: 30
+          absoluteY: 1654
+          width: 2320
+          items:
+            - !image
+              maxWidth: 2320
+              maxHeight: 48
+              url: '/${configDir}/print_header.png'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1582
+          width: 2320
+          widths: [2320]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 14
+              text: '${mapTitle}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 1534
+          width: 2320
+          widths: [2320]
+          items:
+            - !text
+              align: left
+              vertAlign: middle
+              fontSize: 9
+              text: '${comment}'
+        - !map
+          absoluteX: 30
+          absoluteY: 1510
+          height: 1432
+          width: 2320
+        - !columns
+          absoluteX: 2310
+          absoluteY: 138
+          width: 40
+          widths: [40]
+          items:
+            - !image
+              maxWidth: 40
+              maxHeight: 40
+              url:  'file:/${configDir}/Arrow_North_CFCF.svg'
+              rotation: '${rotation}'
+        - !columns
+          absoluteX: 30
+          absoluteY: 54
+          width: 2320
+          widths: [773, 1547]
+          items:
+            - !columns
+              nbColumns: 1
+              items:
+                - !text
+                  width: 773
+                  text: '${now dd.MM.yyyy}'
+                  fontEncoding: Cp1252
+                  fontSize: 9
+                  align: left
+                  vertAlign: middle
+            - !scalebar
+              align: right
+              vertAlign: middle
+              maxSize: 250
+              type: 'bar sub'
+              intervals: 5
+    lastPage:
+      rotation: true
+      pageSize: 2380 1684
+      landscape: false
+      items:
+        #legend panel
+        - !columns
+          config:
+            borderWidth: 0
+            cells:
+              - borderWidth: 0
+                borderWidthLeft: 0
+                borderColor: black
+                padding: 4
+                backgroundColor: white
+                vertAlign: bottom
+          widths: [2320]
+          absoluteX: 30
+          absoluteY: 1624
+          width: 2320
+          items:
+            - !legends
+              failOnBrokenUrl: false
+              horizontalAlignment: left
+              iconMaxWidth: 0
+              iconMaxHeight: 1544
+              maxHeight: 1594
+              maxColumns: 1
+              maxWidth: 2320
+              layerSpace: 5
+              layerFontSize: 12
+              classIndentation: 5
+              classFontSize: 8
+              classSpace: 4
+              backgroundColor:  #ffffff
+              reorderColumns: true
+              dontBreakItems: true
+              overflow: true


### PR DESCRIPTION
Updated yaml configuration file to be able to print map also in the formats A2 and A1 (issue is [here](https://github.com/geosolutions-it/PUBLIACQUA-C179/issues/54))
