### PR TITLE
Replaced fixed memberOf with a template string 

### DIFF
--- a/web/src/main/resources-filtered/WEB-INF/classes/geostore-spring-security.xml
+++ b/web/src/main/resources-filtered/WEB-INF/classes/geostore-spring-security.xml
@@ -101,7 +101,7 @@
                                         <bean id="userSearch"
                                                 class="org.springframework.security.ldap.search.FilterBasedLdapUserSearch">
                                                 <constructor-arg index="0" value="" />
-                                                <constructor-arg index="1" value="(&amp;(objectCategory=${LDAP_USER_SEARCH_CATEGORY})(|(memberOf=${LDAP_USER_SEARCH_MEMBER_OF_1})(memberOf=${LDAP_USER_SEARCH_MEMBER_OF_2})(memberOf=${LDAP_USER_SEARCH_MEMBER_OF_3})(memberOf=${LDAP_USER_SEARCH_MEMBER_OF_4}))(sAMAccountName={0}))" />
+                                                <constructor-arg index="1" value="(&amp;(objectCategory=${LDAP_USER_SEARCH_CATEGORY})(|#LDAP_GROUPS)(sAMAccountName={0}))" />
                                                 <constructor-arg index="2" ref="contextSource" />
                                         </bean>
                                 </property>


### PR DESCRIPTION
In order to be able to modify this xml in a sort of template, we replacing fixed memberOf with the string #LDAP_GROUPS that will be replaced by jenkins once new deploy is launched. In this way we can configure a list of LDAP group from jenkins at runtime, without the need to commit and push to master.